### PR TITLE
Harden spatial tagging workflow specification

### DIFF
--- a/openspec/changes/harden-spatial-tagging-workflow/.openspec.yaml
+++ b/openspec/changes/harden-spatial-tagging-workflow/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-17

--- a/openspec/changes/harden-spatial-tagging-workflow/design.md
+++ b/openspec/changes/harden-spatial-tagging-workflow/design.md
@@ -1,0 +1,99 @@
+## Context
+
+Tag discovery, UI selection state, family validation, matching, and Revit document mutation are currently interleaved. Existing tags store only `SpatialElementId`, which identifies an element inside its source document but not the link instance through which it is tagged. The dialog also persists collection indexes and uses code-behind events to refresh dependent selections, allowing the visible selection and the collected element set to diverge.
+
+The change must work on the Revit 2020-2024 .NET Framework 4.8 targets and the Revit 2025-2026 .NET 8 Windows targets. Revit API objects remain UI-thread-bound, and every family load, type parameter change, and family-instance mutation must occur within a valid transaction.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Give every host or linked spatial element a deterministic source identity that distinguishes repeated instances of the same link.
+- Validate the complete operation before mutation and produce explicit created, updated, skipped, and failed outcomes.
+- Keep dialog state internally consistent and make command availability reflect whether an operation can run.
+- Preserve compatible legacy tags and upgrade them only when their identity is unambiguous.
+- Keep host/link coordinate conversion explicit and testable.
+- Restore clean, reproducible builds for representative legacy and current Revit targets.
+
+**Non-Goals:**
+
+- Automatically delete or merge duplicate tags already present in a model.
+- Support area-based or boundary-derived placement when a spatial element has no `LocationPoint`.
+- Redesign the WPF dialog or add background/asynchronous Revit document access.
+- Change installer technology or remove support for any Revit version from 2020 through 2026.
+- Infer a legacy tag's link source when multiple sources are plausible.
+
+## Decisions
+
+### Store composite source identity on every tag
+
+Keep `SpatialElementId` for backward compatibility and add text parameters for `SourceDocumentId` and `SourceLinkInstanceId`. `SourceDocumentId` uses a stable document-level identifier available in every supported Revit version, preferring the worksharing central GUID where applicable and otherwise using a stable model identifier such as the project-information unique ID. Host tags use the active document ID and an empty link-instance ID; linked tags use the linked document ID and the selected `RevitLinkInstance.UniqueId`.
+
+The update key is `(SourceDocumentId, SourceLinkInstanceId, SpatialElementId)`. This separates two placements of the same linked model while retaining deterministic host updates. Existing tags with only `SpatialElementId` are eligible for in-place migration only when exactly one selected source can own that ID and exactly one legacy tag matches. Ambiguous tags are skipped and reported.
+
+Rejected alternatives:
+
+- `SpatialElementId` alone cannot distinguish documents or repeated link instances.
+- Link name or file path is mutable and is not unique when the same model is placed repeatedly.
+- Encoding all identity into the existing parameter would break existing integrations and make migration opaque.
+
+### Build an operation plan before opening a mutation transaction
+
+Discovery creates typed operation records containing source identity, transformed host point, desired values, matching tag, editability, and outcome. Required family parameters are validated for presence, storage type, and writability before placement starts. Existing tags are indexed by composite key rather than scanned repeatedly.
+
+For linked elements, the source point is transformed exactly once with the selected link instance's transform while planning. Host points are left unchanged. An unloaded or subsequently unavailable link invalidates the plan and is reported without opening a transaction.
+
+The run uses a `TransactionGroup` containing narrowly named transactions for any family-type height change and tag mutations. The group is assimilated only after required mutations succeed. Non-editable or ambiguous individual tags are planned as skips and do not cause a duplicate to be created. Unexpected Revit failures roll back the active transaction/group and are surfaced to the user. The broad duplicate-instance warning suppression is removed because duplicates are no longer an accepted fallback.
+
+Rejected alternatives:
+
+- One transaction per spatial element would allow partial results and add Revit transaction overhead.
+- Continuing to create a replacement for a non-editable tag preserves apparent throughput but corrupts model intent.
+- Catching parameter exceptions and reporting success would retain the current partial-success ambiguity.
+
+### Make selection state view-model-owned and object-based
+
+The view model owns `SelectedTarget`, `FromLink`, `SelectedLink`, `SelectedPhase`, and `SelectedFamilySymbol`. A change to any upstream selection clears dependent data and recollects only when the required inputs are present. The view binds selected objects rather than persisted collection indexes; saved preferences are resolved against current collections and ignored when unavailable.
+
+`RunCommand.CanExecute` is derived from a compatible family, selected phase, non-empty taggable elements, and—when linked mode is active—a loaded selected link. A separate `HasLoadedLinks` Boolean controls link-mode availability. Code-behind is limited to view-only behavior and no longer coordinates domain state.
+
+Rejected alternatives:
+
+- Repairing individual XAML bindings would not prevent stale collections created by event ordering.
+- Retaining index-based selection makes settings invalid whenever collection ordering or available family types change.
+
+### Treat the bundled family schema as a versioned compatibility contract
+
+The bundled and versioned `3dSpatialElementTag` family assets gain the two source-identity text parameters. Family symbols are considered compatible only when `Name`, `Number`, `SpatialElementId`, `SourceDocumentId`, `SourceLinkInstanceId`, and `Text Height` meet their required storage and mutability rules. Incompatible custom families remain untouched and are reported; the add-in does not silently rewrite user-authored families.
+
+The embedded family remains the installation fallback. Installer packaging is verified after the resource update. A schema/version marker may be added if implementation shows parameter inspection alone cannot distinguish revisions consistently across supported Revit releases.
+
+### Separate deterministic logic for automated tests
+
+Source-key construction, legacy-match resolution, selection-state transitions, parameter-validation results, and operation-summary formatting are extracted from direct Revit mutations where practical. These units receive automated coverage on both target-framework families. Revit integration behavior is still manually verified using `_testFiles/main.rvt`, `_testFiles/link.rvt`, and `_testFiles/link2.rvt`, including a transformed link and two instances of the same link.
+
+Dependency versions are pinned after confirming the version compatible with each Revit target. The unused `Microsoft.Net.Http` reference is removed; `PresentationFramework.Aero2` is retained only if visual verification proves it is required and compatible.
+
+## Risks / Trade-offs
+
+- [Existing family assets lack the new parameters] -> Update every shipped family source, embed the upgraded resource, and verify installer contents before release.
+- [A stable document identifier behaves differently across Revit versions or detached models] -> Centralize identifier selection behind one adapter and manually test workshared, non-workshared, detached, and linked fixtures on representative legacy/current versions.
+- [Legacy tags cannot always be attributed safely] -> Migrate only one-to-one unambiguous matches and report the remainder without mutation.
+- [A link is unloaded after the dialog opens] -> Revalidate the selected link immediately before planning and disable or abort the command with a clear message.
+- [Transaction-group rollback removes otherwise successful tag changes] -> Prefer atomic model consistency; report the failure so the user can correct the family or ownership issue and retry.
+- [Pinned Nice3point packages differ by Revit version] -> Pin per supported Revit version/configuration rather than forcing a single package version across incompatible APIs.
+
+## Migration Plan
+
+1. Update and verify all bundled/versioned family assets with the composite identity parameters.
+2. Ship code that reads both the new composite identity and the legacy `SpatialElementId` representation.
+3. On update, write the composite identity to newly created tags and to legacy tags only after an unambiguous match.
+4. Leave ambiguous and non-editable legacy tags unchanged and include them in the operation summary.
+5. Validate `Debug R24` and `Debug R26`, then exercise the manual host/link/worksharing matrix before packaging.
+6. Roll back by restoring the prior add-in and family resource; newly written text parameters remain harmless to the prior version, although it will fall back to legacy matching behavior.
+
+## Open Questions
+
+- Confirm the exact shared/family parameter GUIDs and whether existing released families already reserve suitable identity parameters.
+- Confirm which stable non-workshared document identifier is preserved by the supported Revit releases and by the project's typical copy/detach workflows.
+- Decide whether skipped ownership conflicts should be shown only in the completion summary or also selected/highlighted in Revit.

--- a/openspec/changes/harden-spatial-tagging-workflow/proposal.md
+++ b/openspec/changes/harden-spatial-tagging-workflow/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+The current tagging workflow can update the wrong tag when the same linked model is placed more than once, create hidden duplicates when an existing tag is not editable, and operate on stale or invalid UI selections. These failures can silently produce incorrect Revit model data, so the workflow needs stronger source identity, validation, and user-visible failure handling across Revit 2020-2026.
+
+## What Changes
+
+- Identify a linked spatial element by its source element, source document, and specific link instance so repeated placements do not overwrite one another.
+- Preserve existing host-tag update behavior while migrating legacy tags only when their source can be resolved unambiguously.
+- Skip and report existing tags that cannot be edited instead of creating overlapping replacements and suppressing the warning.
+- Keep target type, link mode, selected link, phase, and collected spatial elements synchronized whenever the user changes a selection.
+- Exclude unloaded links from tagging choices and handle a link becoming unavailable without crashing.
+- Validate the selected tag family and all required parameters before starting mutations; report incompatible families and invalid text heights to the user.
+- Gate the Create/Update command on a complete, valid selection rather than fragile index and XAML bindings.
+- Add automated coverage for deterministic workflow logic and define manual Revit verification for host models, transformed links, repeated link instances, worksharing, and invalid family data.
+- Remove obsolete package references where unused and pin compatible dependency versions so supported Revit builds are reproducible and free of avoidable compatibility warnings.
+
+This change affects every supported configuration from Revit 2020 through Revit 2026. It does not change the visual design of the dialog, add support for non-point spatial element locations, delete existing duplicate tags automatically, or narrow the supported Revit-version range.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `spatial-tagging`: Strengthen source identity, update behavior, selection synchronization, family validation, command availability, error reporting, and linked-model availability requirements.
+
+## Impact
+
+- Primary code impact: `ThreeDeeRoomTagModel`, `ThreeDeeRoomTagViewModel`, `ThreeDeeRoomTagView`, tag-family parameter handling, and failure preprocessing.
+- The bundled `3dSpatialElementTag.rfa` family and versioned family assets may require new source-identity parameters; installers must continue packaging the compatible family resource.
+- Existing tags containing only `SpatialElementId` remain supported through a conservative, unambiguous migration path. Ambiguous legacy tags are reported and left unchanged.
+- Revit document changes remain transaction-bound; discovery and validation occur before mutation, with text-height and tag changes coordinated to avoid partial success.
+- Project dependency declarations and build verification change, but no public API or external service is introduced.

--- a/openspec/changes/harden-spatial-tagging-workflow/specs/spatial-tagging/spec.md
+++ b/openspec/changes/harden-spatial-tagging-workflow/specs/spatial-tagging/spec.md
@@ -1,0 +1,145 @@
+## MODIFIED Requirements
+
+### Requirement: Spatial element selection
+
+The add-in SHALL allow a user to select either Rooms or MEP Spaces from a selected project phase, SHALL keep collected elements synchronized with the current target, source, link, and phase selections, and SHALL discard saved selections that are unavailable in the current document.
+
+#### Scenario: Select host elements by phase
+
+- **WHEN** a user selects a target type and a phase in the active document
+- **THEN** the add-in lists spatial elements of that type whose phase matches the selected phase
+
+#### Scenario: Change the target type
+
+- **WHEN** a user changes the target from Rooms to MEP Spaces or from MEP Spaces to Rooms
+- **THEN** the add-in clears the previously collected elements and refreshes them only for the new target and current valid source selections
+
+#### Scenario: Restore an unavailable saved selection
+
+- **WHEN** a saved family, link, or collection index does not resolve to an available object in the current document
+- **THEN** the add-in leaves that selection unset and does not run with a different object at the saved index
+
+### Requirement: Linked model support
+
+The add-in SHALL allow spatial elements to be sourced only from a loaded Revit link, SHALL place their tags at the corresponding host-document coordinates, and SHALL distinguish separate instances of the same linked document when creating or updating tags.
+
+#### Scenario: Tag an element from a transformed link
+
+- **WHEN** a user selects a loaded link whose transform is not identity and creates tags
+- **THEN** each created tag is positioned using the selected link instance transform applied once to the linked spatial element location
+
+#### Scenario: Tag two instances of the same linked model
+
+- **WHEN** the same linked document is placed through two link instances and the same source spatial element is tagged from each instance
+- **THEN** the add-in creates or updates one distinct host tag for each link instance without moving or replacing the other instance's tag
+
+#### Scenario: Encounter an unloaded link
+
+- **WHEN** a link is unloaded or unavailable before collection or immediately before tag creation
+- **THEN** the add-in does not query or mutate that linked document and reports that the link must be loaded
+
+### Requirement: Tag family availability
+
+The add-in SHALL make the bundled `3dSpatialElementTag` family available when no compatible family is loaded and SHALL accept a family symbol for tagging only when all required value, identity, and text-height parameters have compatible storage and access.
+
+#### Scenario: Load the bundled family
+
+- **WHEN** the tag dialog opens and no compatible `3dSpatialElementTag` family is loaded
+- **THEN** the add-in loads the installed or embedded family resource containing the required parameters and offers its symbols for selection
+
+#### Scenario: Reject an incompatible family
+
+- **WHEN** a candidate family is missing Name, Number, SpatialElementId, SourceDocumentId, SourceLinkInstanceId, or Text Height, or a required parameter has an incompatible storage type
+- **THEN** the add-in does not use that family for tag mutations and reports the compatibility problem
+
+### Requirement: Tag creation
+
+The add-in SHALL create a non-structural family instance for each taggable spatial element, populate its Name and Number, and store the source element, source document, and link-instance identity required for later updates.
+
+#### Scenario: Create a tag for a valid host room
+
+- **WHEN** a selected host room has a point location, non-empty name and number, and no matching tag
+- **THEN** the add-in creates a tag at that location with matching values, the room unique identifier, the host document identifier, and an empty link-instance identifier
+
+#### Scenario: Create a tag for a valid linked space
+
+- **WHEN** a selected linked MEP Space is taggable and has no matching tag for the selected link instance
+- **THEN** the add-in creates a tag at its transformed host point and stores the linked document, link instance, and spatial element identifiers
+
+#### Scenario: Skip an invalid spatial element
+
+- **WHEN** a selected spatial element has no point location or has an empty name or number
+- **THEN** the add-in does not create a tag for that element and includes it in the skipped result count
+
+### Requirement: Existing tag updates
+
+The add-in SHALL update only a matching editable tag when update mode is enabled, SHALL NOT create a replacement when the match is non-editable or ambiguous, and SHALL migrate a legacy identifier only when the source match is unambiguous.
+
+#### Scenario: Update an existing host tag
+
+- **WHEN** update mode is enabled and an editable tag's source document, empty link-instance identifier, and SpatialElementId match a selected host spatial element
+- **THEN** the add-in updates the tag type, position, name, and number without creating another tag
+
+#### Scenario: Update a tag from one repeated link instance
+
+- **WHEN** update mode is enabled and a tag's source document, link-instance identifier, and SpatialElementId match a selected linked spatial element
+- **THEN** the add-in updates that tag without modifying the tag belonging to another instance of the same link
+
+#### Scenario: Existing tag is owned by another user
+
+- **WHEN** a matching tag is not editable because of worksharing ownership or model-update state
+- **THEN** the add-in leaves that tag unchanged, does not create an overlapping replacement, and reports the skipped ownership conflict
+
+#### Scenario: Migrate an unambiguous legacy tag
+
+- **WHEN** exactly one legacy tag contains a matching SpatialElementId and exactly one current source can own that identifier
+- **THEN** the add-in updates the tag and writes its source document and link-instance identity
+
+#### Scenario: Preserve an ambiguous legacy tag
+
+- **WHEN** a legacy SpatialElementId could match more than one source or more than one legacy tag
+- **THEN** the add-in leaves the legacy tags unchanged, creates no replacement, and reports the ambiguity
+
+### Requirement: Configurable text height
+
+The add-in SHALL apply and retain a valid text height for the selected compatible family type and SHALL reject an invalid or unwritable height without reporting it as successfully applied.
+
+#### Scenario: Apply a valid height
+
+- **WHEN** a user enters a valid feet-and-inches value and runs tag creation with a writable Text Height parameter
+- **THEN** the selected family type's Text Height is updated within the coordinated mutation and the entered value is saved in user settings
+
+#### Scenario: Reject an invalid height
+
+- **WHEN** the entered text height cannot be parsed as a positive supported model-unit value
+- **THEN** the add-in does not save or apply the value and reports the validation error
+
+## ADDED Requirements
+
+### Requirement: Tagging command readiness
+
+The add-in SHALL enable the Create/Update command only when the current selections form a valid tagging operation.
+
+#### Scenario: Complete host selection
+
+- **WHEN** a compatible family, target type, phase, and at least one taggable host spatial element are selected
+- **THEN** the Create/Update command is enabled
+
+#### Scenario: Incomplete linked selection
+
+- **WHEN** linked mode is selected without a loaded selected link or without collected taggable elements
+- **THEN** the Create/Update command is disabled
+
+### Requirement: Tagging operation result
+
+The add-in SHALL report created, updated, skipped, and failed outcomes without presenting a rolled-back or rejected mutation as successful.
+
+#### Scenario: Complete with skipped elements
+
+- **WHEN** valid tags are created or updated while other elements are skipped for invalid data, ownership, or ambiguity
+- **THEN** the completion result reports each outcome count and provides a reason for each skipped category
+
+#### Scenario: Unexpected mutation failure
+
+- **WHEN** an unexpected Revit failure prevents the coordinated mutation from completing
+- **THEN** the add-in rolls back the coordinated changes and reports the failure instead of a success count

--- a/openspec/changes/harden-spatial-tagging-workflow/tasks.md
+++ b/openspec/changes/harden-spatial-tagging-workflow/tasks.md
@@ -1,0 +1,41 @@
+## 1. Deterministic Workflow Foundations
+
+- [ ] 1.1 Add a test project that can exercise framework-neutral tagging workflow logic for the .NET Framework 4.8 and .NET 8 Windows target families, and verify the empty suite in `Debug R24` and `Debug R26`.
+- [ ] 1.2 Implement the composite source identity value type and document-identity adapter, with tests for host elements, transformed linked elements, and two instances of the same linked document.
+- [ ] 1.3 Implement typed family-parameter validation and operation-result models, with tests for missing parameters, wrong storage types, read-only parameters, invalid height values, and outcome aggregation.
+
+## 2. Family And Link Compatibility
+
+- [ ] 2.1 Add `SourceDocumentId` and `SourceLinkInstanceId` text parameters to the embedded `source/ThreeDeeRoomTags/Resources/3dSpatialElementTag.rfa` and each supported source family under `revit/`, preserving the legacy `SpatialElementId` parameter.
+- [ ] 2.2 Update family discovery to offer only compatible symbols, load the upgraded bundled family when required, and return an actionable compatibility result instead of dereferencing missing parameters.
+- [ ] 2.3 Filter unavailable link instances during discovery and revalidate `GetLinkDocument()` immediately before collection and operation planning.
+- [ ] 2.4 Verify the upgraded family resource is embedded in `Debug R24` and `Debug R26` outputs and included by the existing installer/bundle pipeline.
+
+## 3. Tag Planning And Transactions
+
+- [ ] 3.1 Build an operation planner that validates source data, applies the selected link transform exactly once, and classifies each element as create, update, or skip before opening a mutation transaction; cover host and linked cases with tests.
+- [ ] 3.2 Index existing tags by composite source identity and implement conservative legacy matching, with tests for one-to-one migration, repeated link instances, duplicate legacy tags, and ambiguous document sources.
+- [ ] 3.3 Implement coordinated text-height and tag mutations with explicit transaction/transaction-group rollback, and verify an unexpected failure cannot produce a success result or retain partial changes.
+- [ ] 3.4 Change non-editable matches to skipped ownership/model-update outcomes, remove the duplicate-creation fallback and broad duplicate warning suppression, and test that no replacement operation is planned.
+- [ ] 3.5 Persist composite identity on every created or unambiguously migrated tag and report created, updated, skipped, and failed counts with category-specific reasons.
+
+## 4. View-Model State And Command Safety
+
+- [ ] 4.1 Replace collection-index workflow state with selected target, link, phase, and family objects while resolving existing saved preferences only when they match an available object.
+- [ ] 4.2 Centralize dependent clearing and recollection in the view model so target, link mode, selected link, and phase changes cannot leave stale spatial elements; add state-transition tests for each selection sequence.
+- [ ] 4.3 Derive `RunCommand.CanExecute` and `HasLoadedLinks` from valid workflow state, replace the invalid `Rooms.Count` and integer-to-Boolean bindings, and reduce code-behind to view-only behavior.
+- [ ] 4.4 Surface family, link, height, ownership, ambiguity, and rollback results in the dialog without broad exception swallowing, then verify command enablement and messages through WPF-level tests where practical.
+
+## 5. Dependencies And Automated Verification
+
+- [ ] 5.1 Remove the unused `Microsoft.Net.Http` reference, evaluate whether `PresentationFramework.Aero2` remains necessary, and pin compatible Nice3point and application package versions per supported Revit configuration.
+- [ ] 5.2 Run the automated tests and compile `Debug R24`, confirming zero errors and documenting any unavoidable warnings for the .NET Framework/Revit 2024 configuration.
+- [ ] 5.3 Run the automated tests and compile `Debug R26`, confirming zero errors and documenting any unavoidable warnings for the .NET 8/Revit 2026 configuration.
+
+## 6. Manual Revit Verification
+
+- [ ] 6.1 Using `_testFiles/main.rvt`, verify Room and MEP Space selection changes refresh the correct host elements, invalid selections disable the command, valid tags create/update, and invalid family or height data is reported without mutation.
+- [ ] 6.2 Using `_testFiles/main.rvt`, `_testFiles/link.rvt`, and `_testFiles/link2.rvt`, verify transformed coordinates, unloaded-link handling, and independent create/update behavior for two instances of the same linked document.
+- [ ] 6.3 In a workshared copy of `_testFiles/main.rvt`, verify a tag owned by another user is skipped and reported without creating a duplicate or suppressing a duplicate warning.
+- [ ] 6.4 Verify one unambiguous legacy tag is migrated, ambiguous legacy tags remain unchanged and reported, and the upgraded bundled family loads correctly in representative Revit 2024 and Revit 2026 sessions.
+- [ ] 6.5 Build the release installer/bundle, install it for a representative legacy and current Revit version, and confirm the manifest, assemblies, and upgraded family resource are packaged and load successfully.


### PR DESCRIPTION
## What changed

- Added the `harden-spatial-tagging-workflow` OpenSpec proposal.
- Defined the technical design for composite linked-element identity, safe transaction handling, synchronized WPF state, family validation, and legacy-tag migration.
- Added a `spatial-tagging` delta spec with observable host, linked-model, worksharing, validation, and result-reporting requirements.
- Added an ordered implementation and verification checklist covering Revit 2020-2026, family resources, automated tests, manual fixtures, dependencies, and installer validation.

## Why

The codebase audit found cases where repeated link instances can update the wrong tag, non-editable workshared tags can produce hidden duplicates, and stale or invalid UI state can drive incorrect operations. The proposal turns those findings into an implementation-ready, compatibility-conscious specification before production code changes begin.

## Impact

This PR changes planning artifacts only. It does not modify add-in behavior or shipped family resources yet. The implementation plan preserves Revit 2020-2026 support and includes conservative migration for legacy tags that only store `SpatialElementId`.

## Validation

- `openspec validate harden-spatial-tagging-workflow --strict`
- OpenSpec status: 4/4 artifacts complete
- `git diff --cached --check`
